### PR TITLE
Make relations ordered

### DIFF
--- a/src/ch/akuhn/fame/internal/MultivalueSet.java
+++ b/src/ch/akuhn/fame/internal/MultivalueSet.java
@@ -19,13 +19,13 @@
 package ch.akuhn.fame.internal;
 
 import java.util.AbstractSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 public abstract class MultivalueSet<T> extends AbstractSet<T> {
 
-    private Set<T> values = new HashSet<T>();
+    private Set<T> values = new LinkedHashSet<T>();
 
     @Override
     public boolean add(T e) {


### PR DESCRIPTION
All relations implemented with [`MultivalueSet`](https://github.com/moosetechnology/FameJava/blob/4b624c9c7fc23dca62371212f2657deed17a0b6c/src/ch/akuhn/fame/internal/MultivalueSet.java) are currently unordered.
The lack of order can be detrimental when analyzing parameterized types or parameters for example.

This fix suggests using a `LinkedHashSet` instead of a `HashSet` for the internal collection used by `MultivalueSet`, as this data structure keeps track of the insertion order.