### PR TITLE
modified printing of properties to avoid extra "," for entity with no property

### DIFF
--- a/lib/src/main/java/ch/akuhn/fame/internal/JSONPrettyPrinter.java
+++ b/lib/src/main/java/ch/akuhn/fame/internal/JSONPrettyPrinter.java
@@ -39,8 +39,7 @@ public class JSONPrettyPrinter extends AbstractPrintClient {
         lntabs();
         append("\"FM3\":\"");
         append(name);
-        append("\",");
-        lntabs();
+        append("\"");
     }
 
     public void beginMultivalue(String name) {
@@ -121,9 +120,10 @@ public class JSONPrettyPrinter extends AbstractPrintClient {
 
     @Override
     public void serial(int index) {
+    	printPropertySeparator();
+    	lntabs();
         append("\"id\":");
         append(String.valueOf(index));
-        append(",");
     }
 
     public void printEntitySeparator() {

--- a/lib/src/main/java/ch/akuhn/fame/internal/JSONPrinter.java
+++ b/lib/src/main/java/ch/akuhn/fame/internal/JSONPrinter.java
@@ -30,7 +30,7 @@ public class JSONPrinter extends AbstractPrintClient {
         append("{");
         append("\"FM3\":\"");
         append(name);
-        append("\",");
+        append("\"");
     }
 
     public void beginMultivalue(String name) {
@@ -104,9 +104,9 @@ public class JSONPrinter extends AbstractPrintClient {
 
     @Override
     public void serial(int index) {
+    	printPropertySeparator();
         append("\"id\":");
         append(String.valueOf(index));
-        append(",");
     }
 
     public void printEntitySeparator() {

--- a/lib/src/main/java/ch/akuhn/fame/internal/RepositoryVisitor.java
+++ b/lib/src/main/java/ch/akuhn/fame/internal/RepositoryVisitor.java
@@ -79,6 +79,8 @@ public class RepositoryVisitor implements Runnable {
                     continue;
             }*/
             if (!values.isEmpty()) {
+            	visitor.printEntitySeparator();
+
                 visitor.beginAttribute(property.getName());
                 if (property.isMultivalued()) {
                     visitor.beginMultivalue(property.getName());
@@ -131,9 +133,6 @@ public class RepositoryVisitor implements Runnable {
                     visitor.endMultivalue(property.getName());
                 }
                 visitor.endAttribute(property.getName());
-                if (propertiesIterator.hasNext()) {
-                    visitor.printEntitySeparator();
-                }
             }
         }
     }

--- a/lib/src/test/java/ch/akuhn/fame/test/JSONPrinterTest.java
+++ b/lib/src/test/java/ch/akuhn/fame/test/JSONPrinterTest.java
@@ -1,7 +1,9 @@
 package ch.akuhn.fame.test;
 
+import ch.akuhn.fame.MetaRepository;
 import ch.akuhn.fame.Tower;
 import ch.akuhn.fame.internal.JSONPrettyPrinter;
+import ch.akuhn.fame.internal.JSONPrinter;
 import ch.akuhn.fame.parser.InputSource;
 import junit.framework.TestCase;
 
@@ -10,6 +12,9 @@ public class JSONPrinterTest extends TestCase {
     private JSONPrettyPrinter printer;
     private Appendable stream;
 
+    /** FIXME
+     * This is not a test but a method to export a meta-model
+     */
     public void testExportJSON() {
         InputSource input = InputSource.fromResource("ch/unibe/fame/resources/lib.mse");
         Tower t = new Tower();
@@ -28,46 +33,83 @@ public class JSONPrinterTest extends TestCase {
 
     public void testBeginAttributeSimple() {
         printer.beginAttribute("hello");
-        assertEquals(stream.toString(), "\"hello\":");
+        assertEquals("\"hello\":", stream.toString());
     }
 
     public void testPrimitive() {
         printer.primitive("value");
-        assertEquals(stream.toString(), "\"value\"");
+        assertEquals("\"value\"", stream.toString());
     }
 
     public void testPrimitiveWithSpecialCharacter() {
         printer.primitive("MySuper\"String");
-        assertEquals(stream.toString(), "\"MySuper\\\"String\"");
+        assertEquals("\"MySuper\\\"String\"", stream.toString());
     }
 
     public void testPrimitiveWithSpecialCharacterAndActualExample() {
         printer.primitive("print(\"Printer \" + name() + \" prints \"+ thePacket.contents(),false)");
-        assertEquals(stream.toString(), "\"print(\\\"Printer \\\" + name() + \\\" prints \\\"+ thePacket.contents(),false)\"");
+        assertEquals( "\"print(\\\"Printer \\\" + name() + \\\" prints \\\"+ thePacket.contents(),false)\"", stream.toString());
     }
 
     public void testReference() {
         printer.reference("hello");
-        assertEquals(removeWhiteSpaces(stream.toString()), "{\"ref\":\"hello\"}");
+        assertEquals("{\"ref\":\"hello\"}", removeWhiteSpaces(stream.toString()));
     }
 
     public void testReferenceIndex() {
         printer.reference(2);
-        assertEquals(removeWhiteSpaces(stream.toString()), "{\"ref\":2}");
+        assertEquals("{\"ref\":2}", removeWhiteSpaces(stream.toString()));
     }
 
     public void testSerial() {
         printer.serial(2);
-        assertEquals(removeWhiteSpaces(stream.toString()), "\"id\":2,");
+        assertEquals(",\"id\":2", removeWhiteSpaces(stream.toString()));
     }
 
     public void testBeginElement() {
         printer.beginElement("Java.Class");
-        assertEquals(removeWhiteSpaces(stream.toString()), "{\"FM3\":\"Java.Class\",");
+        assertEquals("{\"FM3\":\"Java.Class\"", removeWhiteSpaces(stream.toString()));
     }
 
 
     private static String removeWhiteSpaces(String input) {
         return input.replaceAll("\\s+", "");
     }
+
+    public void testEmptyEntityPrettyPrinter() {
+        String str = "((FM3.Package))";
+        Tower t = new Tower();
+        t.getMetamodel().importMSE(str);
+        MetaRepository repo = t.getMetamodel();
+        repo.accept( printer);
+        assertEquals("[{\"FM3\":\"FM3.Package\",\"id\":1}]", removeWhiteSpaces(stream.toString()));
+    }
+
+    public void testEmptyEntityJSONPrinter() {
+        String str = "((FM3.Package))";
+        Tower t = new Tower();
+        t.getMetamodel().importMSE(str);
+        MetaRepository repo = t.getMetamodel();
+        repo.accept( new JSONPrinter(stream));
+        assertEquals("[{\"FM3\":\"FM3.Package\",\"id\":1}]", stream.toString());
+    }
+
+    public void testEntityWithAttributePrettyPrinter() {
+        String str = "((FM3.Package (name 'Blah')))";
+        Tower t = new Tower();
+        t.getMetamodel().importMSE(str);
+        MetaRepository repo = t.getMetamodel();
+        repo.accept( printer);
+        assertEquals("[{\"FM3\":\"FM3.Package\",\"id\":1,\"name\":\"Blah\"}]", removeWhiteSpaces(stream.toString()));
+    }
+
+    public void testEntityWithAttributeJSONPrinter() {
+        String str = "((FM3.Package (name 'Blah')))";
+        Tower t = new Tower();
+        t.getMetamodel().importMSE(str);
+        MetaRepository repo = t.getMetamodel();
+        repo.accept( new JSONPrinter(stream));
+        assertEquals("[{\"FM3\":\"FM3.Package\",\"id\":1,\"name\":\"Blah\"}]", stream.toString());
+    }
+
 }

--- a/lib/src/test/java/ch/akuhn/fame/test/JSONPrinterTest.java
+++ b/lib/src/test/java/ch/akuhn/fame/test/JSONPrinterTest.java
@@ -24,6 +24,10 @@ public class JSONPrinterTest extends TestCase {
         System.out.println(stream);
     }
 
+    private static String removeWhiteSpaces(String input) {
+        return input.replaceAll("\\s+", "");
+    }
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -69,11 +73,6 @@ public class JSONPrinterTest extends TestCase {
     public void testBeginElement() {
         printer.beginElement("Java.Class");
         assertEquals("{\"FM3\":\"Java.Class\"", removeWhiteSpaces(stream.toString()));
-    }
-
-
-    private static String removeWhiteSpaces(String input) {
-        return input.replaceAll("\\s+", "");
     }
 
     public void testEmptyEntityPrettyPrinter() {


### PR DESCRIPTION
There was a mandatory comma after the serial in JSON
This caused problems for entities without properties (see #18)
Changed the way properties are separated in  JSON (by printing the separator before the property and not after)
Added tests also (for JSONPrettyPrinter, JSONPrinter and MSEPRinter)