### PR TITLE
Traits management update

### DIFF
--- a/lib/src/main/java/ch/akuhn/fame/codegen/CodeGeneration.java
+++ b/lib/src/main/java/ch/akuhn/fame/codegen/CodeGeneration.java
@@ -340,7 +340,7 @@ public class CodeGeneration {
         }
         // Properties from my traits that are not in my own properties
         Set<PropertyDescription> propertyDescriptionSet = new HashSet<>();
-        metaDescription.getTraits().stream()
+        metaDescription.computeAllTraits().stream()
                 .map(c -> c.getProperties().stream()
                         .filter(traitProperty -> propertyDescriptions.stream().noneMatch(myProperty -> myProperty.getName().equals(traitProperty.getName())))
                         .collect(Collectors.toList()))
@@ -365,7 +365,7 @@ public class CodeGeneration {
         code.setTraits(m.getTraits().stream().map(FM3Type::getName).collect(Collectors.toList()));
         code.addImport(FameDescription.class);
         code.addImport(FamePackage.class);
-        for (FM3Trait t : m.computeAllTraits()) {
+        for (FM3Trait t : m.getTraits()) {
             code.addImport(packageName(t.getPackage()), t.getName());
         }
 

--- a/lib/src/main/java/ch/akuhn/fame/fm3/FM3Trait.java
+++ b/lib/src/main/java/ch/akuhn/fame/fm3/FM3Trait.java
@@ -86,13 +86,21 @@ public class FM3Trait extends FM3Type {
         super(name);
     }
 
-    FM3Type traitOwner;
-    @FameProperty(name = "owner", opposite = "traits")
-    public FM3Type getTraitOwner() {
-        return traitOwner;
-    }
-    public void setTraitOwner(FM3Type traitOwner){
-        this.traitOwner = traitOwner;
+    private Map<String, FM3Type> users = new HashMap<String, FM3Type>();
+
+    @FameProperty(name = "users", opposite = "traits")
+    public Collection<FM3Type> getUsers() {
+        return users.values();
     }
 
+    public void setUsers(Collection<FM3Type> users){
+        for (FM3Type user : users) {
+            this.addUser(user);
+        }
+    }
+
+    public void addUser(FM3Type user) {
+        users.put(user.getName(), user);
+    }
+    
 }

--- a/lib/src/main/java/ch/akuhn/fame/fm3/FM3Type.java
+++ b/lib/src/main/java/ch/akuhn/fame/fm3/FM3Type.java
@@ -156,7 +156,7 @@ public class FM3Type extends Element {
         }
     }
 
-    @FameProperty(name="traits", opposite = "owner")
+    @FameProperty(name="traits", opposite = "users")
     public Collection<FM3Trait> getTraits() {
         return traits.values();
     }
@@ -174,11 +174,16 @@ public class FM3Type extends Element {
     }
 
     public Set<FM3Trait> computeAllTraits() {
-        Set<FM3Trait> traits = new HashSet<>();
-        traits.addAll(getTraits());
-        for (FM3Trait t : traits) {
-            traits.addAll(t.computeAllTraits());
+        Set<FM3Trait> computedTraits = new HashSet<>();
+        computedTraits.addAll(getTraits());
+        Set<FM3Trait> transitiveTraits = new HashSet<>();
+        
+        for (FM3Trait t : computedTraits) {
+            transitiveTraits.addAll(t.computeAllTraits());
         }
-        return traits;
+
+        computedTraits.addAll(transitiveTraits);
+        return computedTraits;
     }
+    
 }


### PR DESCRIPTION
- FM3Trait has now the #users property, and not #owner. Same for the opposite in FM3Type.
- All traits should be computed to generate all appropriate properties in a class but only local traits for the class definition and imports, to avoid redundancy.
- modify iteration in `computeAllTraits()` to avoid conflicts.